### PR TITLE
Add support for module paths to require-import-fragment

### DIFF
--- a/packages/plugin/__tests__/mocks/import-fragments/baz-fragment/index.gql
+++ b/packages/plugin/__tests__/mocks/import-fragments/baz-fragment/index.gql
@@ -1,0 +1,3 @@
+fragment BazFields on Foo {
+  id
+}

--- a/packages/plugin/__tests__/mocks/import-fragments/baz-fragment/package.json
+++ b/packages/plugin/__tests__/mocks/import-fragments/baz-fragment/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./index.gql"
+}

--- a/packages/plugin/__tests__/mocks/import-fragments/module-import.gql
+++ b/packages/plugin/__tests__/mocks/import-fragments/module-import.gql
@@ -1,0 +1,7 @@
+# import './baz-fragment'
+
+query {
+  foo {
+    ...BazFields
+  }
+}

--- a/packages/plugin/__tests__/require-import-fragment.spec.ts
+++ b/packages/plugin/__tests__/require-import-fragment.spec.ts
@@ -13,6 +13,7 @@ function withMocks({ name, filename, errors }: { name: string; filename: string;
           filename,
           join(__dirname, 'mocks/import-fragments/foo-fragment.gql'),
           join(__dirname, 'mocks/import-fragments/bar-fragment.gql'),
+          join(__dirname, 'mocks/import-fragments/baz-fragment/index.gql'),
         ],
       },
     } satisfies ParserOptionsForTests,
@@ -33,6 +34,10 @@ ruleTester.run('require-import-fragment', rule, {
     withMocks({
       name: 'should not report fragments from the same file',
       filename: join(__dirname, 'mocks/import-fragments/same-file.gql'),
+    }),
+    withMocks({
+      name: 'should not report with module import',
+      filename: join(__dirname, 'mocks/import-fragments/module-import.gql'),
     }),
   ],
   invalid: [

--- a/packages/plugin/src/rules/require-import-fragment.ts
+++ b/packages/plugin/src/rules/require-import-fragment.ts
@@ -91,7 +91,13 @@ export const rule: GraphQLESLintRule = {
           const extractedImportPath = comment.value.match(/(["'])((?:\1|.)*?)\1/)?.[2];
           if (!extractedImportPath) continue;
 
-          const importPath = path.join(path.dirname(filePath), extractedImportPath);
+          let importPath: string;
+          try {
+            importPath = require.resolve(extractedImportPath, { paths: [path.dirname(filePath)] });
+          } catch {
+            importPath = path.join(path.dirname(filePath), extractedImportPath);
+          }
+
           const hasInSiblings = fragmentsFromSiblings.some(
             source => source.filePath === importPath,
           );


### PR DESCRIPTION
## Description

This change modifies the `require-import-fragment` rule to support module paths.

Fixes #2180

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added a new test case to `packages/plugin/__tests__/require-import-fragment.spec.ts`.

**Test Environment**:

- OS: macOS 14.2.1
- `@graphql-eslint/...`: 4.0.0-alpha.0
- NodeJS: 18.12.1

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
