### PR TITLE
exposes GraphQLESTreeNode type

### DIFF
--- a/.changeset/real-coins-share.md
+++ b/.changeset/real-coins-share.md
@@ -1,0 +1,5 @@
+---
+"@graphql-eslint/eslint-plugin": major
+---
+
+exposing GraphQLESTreeNode type

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -8,6 +8,7 @@ import { SiblingOperations } from './siblings.js';
 
 export type Schema = GraphQLSchema | null;
 export type Pointer = string | string[];
+export { GraphQLESTreeNode } from './estree-converter/types.js';
 
 export interface ParserOptions {
   graphQLConfig?: IGraphQLConfig;


### PR DESCRIPTION
## Description

We use some custom eslint plugins that build on top of `@graphql-eslint/eslint-plugin` and it cannot be imported directly from the package if Typescript's config is set to use `moduleResolution: NodeNext` or any other resolution type. This means explicitly making it public is the easiest way to use it.

Fixes #2399

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

No, it is just exposing new type.

**Test Environment**:

N/A

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Unfortunately, I'm not able to make tests pass locally. I get this failure:

```
@graphql-eslint/eslint-plugin:test:  FAIL  __tests__/examples.spec.ts > Examples > should work in monorepo
@graphql-eslint/eslint-plugin:test: Error:
@graphql-eslint/eslint-plugin:test: Oops! Something went wrong! :(
@graphql-eslint/eslint-plugin:test:
@graphql-eslint/eslint-plugin:test: ESLint: 8.57.0
@graphql-eslint/eslint-plugin:test:
@graphql-eslint/eslint-plugin:test: file:///Users/ondrej.synacek/Projects/graphql-eslint/packages/plugin/dist/esm/types.js:2
@graphql-eslint/eslint-plugin:test: import { GraphQLESTreeNode as GraphQLESTreeNode2 } from "./estree-converter/types.js";
@graphql-eslint/eslint-plugin:test:          ^^^^^^^^^^^^^^^^^
@graphql-eslint/eslint-plugin:test: SyntaxError: The requested module './estree-converter/types.js' does not provide an export named 'GraphQLESTreeNode'
es.js' does not provide an export named 'GraphQLESTreeNode'

```

Can I ask for assistance on this one? 🙇 Thanks