### PR TITLE
Stop using experimental syntax to load package version

### DIFF
--- a/.changeset/healthy-moose-kneel.md
+++ b/.changeset/healthy-moose-kneel.md
@@ -1,0 +1,7 @@
+---
+"@graphql-eslint/eslint-plugin": patch
+---
+
+The import attribute syntax (with { type: "json" }) is still experimental so warnings showed up when using the library as it was being used to import the package.json file to extract the package version
+
+As an alternative, the current version will be injected on build time through tsup configuration.

--- a/packages/plugin/__tests__/examples.spec.ts
+++ b/packages/plugin/__tests__/examples.spec.ts
@@ -22,14 +22,10 @@ function getESLintOutput(cwd: string): ESLint.LintResult[] {
   const errorOutput = stderr
     .toString()
     .replace(
-      /\(node:\d{4,5}\) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time/,
+      /\(node:\d{4,7}\) \[DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead./,
       '',
     )
-    .replace(
-      /\(node:\d{4,5}\) \[DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead./,
-      '',
-    )
-    .replace('(Use `node --trace-warnings ...` to show where the warning was created)', '')
+    .replace('(Use `node --trace-deprecation ...` to show where the warning was created)', '')
     .trimEnd();
   if (errorOutput) {
     throw new Error(errorOutput);

--- a/packages/plugin/src/meta.ts
+++ b/packages/plugin/src/meta.ts
@@ -1,3 +1,1 @@
-import packageJson from '../package.json' with { type: 'json' };
-
-export const { version } = packageJson;
+export const version = process.env.VERSION

--- a/packages/plugin/tsup.config.ts
+++ b/packages/plugin/tsup.config.ts
@@ -10,6 +10,7 @@ const opts: Options = {
   dts: true,
   env: {
     ...(process.env.NODE_ENV && { NODE_ENV: process.env.NODE_ENV }),
+    VERSION: packageJson.version,
   },
   format: 'esm',
   minifySyntax: true,


### PR DESCRIPTION
## Description

The import attribute syntax (`with { type: "json" }`) is still experimental so warnings showed up when using the library as it was being used to import the package.json file to extract the package version

As an alternative, the current version will be injected on build time through tsup configuration.

Fixes #2614 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Test suite passes

**Test Environment**:

- OS: Linux
- `@graphql-eslint/plugins`: 4.0.0-alpha.5
- NodeJS: 18

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules