### PR TITLE
`naming-convention` rule should not fail when aliasing underscore fields

### DIFF
--- a/.changeset/unlucky-months-sit.md
+++ b/.changeset/unlucky-months-sit.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+`naming-convention` rule should not fail when aliasing underscore fields

--- a/packages/plugin/src/rules/naming-convention/index.test.ts
+++ b/packages/plugin/src/rules/naming-convention/index.test.ts
@@ -109,7 +109,9 @@ ruleTester.run<RuleOptions>('naming-convention', rule, {
       code: 'query { foo }',
       options: [{ OperationDefinition: { style: 'PascalCase' } }],
     },
-    '{ test { __typename ok_ } }',
+    {
+      code: '{ test { __typename ok_ } }',
+    },
     {
       name: 'should ignore fields',
       code: /* GraphQL */ `
@@ -208,6 +210,17 @@ ruleTester.run<RuleOptions>('naming-convention', rule, {
           },
         },
       ],
+    },
+    {
+      name: 'should not fail when aliasing underscore fields',
+      code: /* GraphQL */ `
+        {
+          test {
+            bar: __foo
+            foo: bar__
+          }
+        }
+      `,
     },
   ],
   invalid: [

--- a/packages/plugin/src/rules/naming-convention/index.ts
+++ b/packages/plugin/src/rules/naming-convention/index.ts
@@ -430,6 +430,9 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
     };
 
     const checkUnderscore = (isLeading: boolean) => (node: GraphQLESTreeNode<NameNode>) => {
+      if (node.parent.kind === 'Field' && node.parent.alias !== node) {
+        return;
+      }
       const suggestedName = node.value.replace(isLeading ? /^_+/ : /_+$/, '');
       report(node, `${isLeading ? 'Leading' : 'Trailing'} underscores are not allowed`, [
         suggestedName,
@@ -439,14 +442,10 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
     const listeners: GraphQLESLintRuleListener = {};
 
     if (!allowLeadingUnderscore) {
-      listeners[
-        'Name[value=/^_/]:matches([parent.kind!=Field], [parent.kind=Field][parent.alias])'
-      ] = checkUnderscore(true);
+      listeners['Name[value=/^_/]'] = checkUnderscore(true);
     }
     if (!allowTrailingUnderscore) {
-      listeners[
-        'Name[value=/_$/]:matches([parent.kind!=Field], [parent.kind=Field][parent.alias])'
-      ] = checkUnderscore(false);
+      listeners['Name[value=/_$/]'] = checkUnderscore(false);
     }
 
     const selectors = new Set(


### PR DESCRIPTION
fixes https://github.com/dimaMachina/graphql-eslint/issues/2430