### PR TITLE
`allowLeadingUnderscore` and `allowTrailingUnderscore` should not conflict with `ignorePattern` in `naming-convention` rule

### DIFF
--- a/.changeset/spotty-lobsters-enjoy.md
+++ b/.changeset/spotty-lobsters-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+`allowLeadingUnderscore` and `allowTrailingUnderscore` should not conflict with `ignorePattern` in `naming-convention` rule

--- a/.changeset/spotty-lobsters-enjoy.md
+++ b/.changeset/spotty-lobsters-enjoy.md
@@ -2,4 +2,5 @@
 '@graphql-eslint/eslint-plugin': patch
 ---
 
-`allowLeadingUnderscore` and `allowTrailingUnderscore` should not conflict with `ignorePattern` in `naming-convention` rule
+`allowLeadingUnderscore` and `allowTrailingUnderscore` should not conflict with `ignorePattern` in
+`naming-convention` rule

--- a/packages/plugin/src/rules/naming-convention/index.test.ts
+++ b/packages/plugin/src/rules/naming-convention/index.test.ts
@@ -229,11 +229,13 @@ ruleTester.run<RuleOptions>('naming-convention', rule, {
           _someField_: Boolean!
         }
       `,
-      options: [{
-        'FieldDefinition[parent.name.value=SomeType]': {
-          ignorePattern: ".*someField.*"
-        }
-      }]
+      options: [
+        {
+          'FieldDefinition[parent.name.value=SomeType]': {
+            ignorePattern: '.*someField.*',
+          },
+        },
+      ],
     },
   ],
   invalid: [
@@ -271,8 +273,8 @@ ruleTester.run<RuleOptions>('naming-convention', rule, {
         },
       ],
       errors: [
-        { message: 'Input "_idOperatorsFilterFindManyUserInput" should be in PascalCase format', },
-        { message: 'Input "_idOperatorsFilterFindOneUserInput" should be in PascalCase format', },
+        { message: 'Input "_idOperatorsFilterFindManyUserInput" should be in PascalCase format' },
+        { message: 'Input "_idOperatorsFilterFindOneUserInput" should be in PascalCase format' },
         { message: 'Input "_idOperatorsFilterRemoveManyUserInput" should be in PascalCase format' },
         { message: 'Input "_idOperatorsFilterRemoveOneUserInput" should be in PascalCase format' },
         { message: 'Input "_idOperatorsFilterUpdateManyUserInput" should be in PascalCase format' },

--- a/packages/plugin/src/rules/naming-convention/index.test.ts
+++ b/packages/plugin/src/rules/naming-convention/index.test.ts
@@ -222,6 +222,19 @@ ruleTester.run<RuleOptions>('naming-convention', rule, {
         }
       `,
     },
+    {
+      name: '`allowLeadingUnderscore` and `allowTrailingUnderscore` should not conflict with `ignorePattern`',
+      code: /* GraphQL */ `
+        type SomeType {
+          _someField_: Boolean!
+        }
+      `,
+      options: [{
+        'FieldDefinition[parent.name.value=SomeType]': {
+          ignorePattern: ".*someField.*"
+        }
+      }]
+    },
   ],
   invalid: [
     {
@@ -258,24 +271,12 @@ ruleTester.run<RuleOptions>('naming-convention', rule, {
         },
       ],
       errors: [
-        {
-          message: 'Input "_idOperatorsFilterFindManyUserInput" should be in PascalCase format',
-        },
-        {
-          message: 'Input "_idOperatorsFilterFindOneUserInput" should be in PascalCase format',
-        },
-        {
-          message: 'Input "_idOperatorsFilterRemoveManyUserInput" should be in PascalCase format',
-        },
-        {
-          message: 'Input "_idOperatorsFilterRemoveOneUserInput" should be in PascalCase format',
-        },
-        {
-          message: 'Input "_idOperatorsFilterUpdateManyUserInput" should be in PascalCase format',
-        },
-        {
-          message: 'Input "_idOperatorsFilterUpdateOneUserInput" should be in PascalCase format',
-        },
+        { message: 'Input "_idOperatorsFilterFindManyUserInput" should be in PascalCase format', },
+        { message: 'Input "_idOperatorsFilterFindOneUserInput" should be in PascalCase format', },
+        { message: 'Input "_idOperatorsFilterRemoveManyUserInput" should be in PascalCase format' },
+        { message: 'Input "_idOperatorsFilterRemoveOneUserInput" should be in PascalCase format' },
+        { message: 'Input "_idOperatorsFilterUpdateManyUserInput" should be in PascalCase format' },
+        { message: 'Input "_idOperatorsFilterUpdateOneUserInput" should be in PascalCase format' },
         { message: 'Input "_idOperatorsFilterUserInput" should be in PascalCase format' },
         { message: 'Enum value "male" should be in UPPER_CASE format' },
         { message: 'Enum value "female" should be in UPPER_CASE format' },

--- a/packages/plugin/src/rules/naming-convention/index.ts
+++ b/packages/plugin/src/rules/naming-convention/index.ts
@@ -342,7 +342,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
   create(context) {
     const options = context.options[0] || {};
     const { allowLeadingUnderscore, allowTrailingUnderscore, types, ...restOptions } = options;
-    const ignoredNodes = new Set<unknown>()
+    const ignoredNodes = new Set<unknown>();
 
     function normalisePropertyOption(kind: string): PropertySchema {
       const style = (restOptions[kind] || types) as Options;
@@ -405,7 +405,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
         const name = nodeName.replace(/(^_+)|(_+$)/g, '');
         if (ignorePattern && new RegExp(ignorePattern, 'u').test(name)) {
           if ('name' in n) {
-            ignoredNodes.add(n.name)
+            ignoredNodes.add(n.name);
           }
           return;
         }
@@ -490,7 +490,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
 
     const checkUnderscore = (isLeading: boolean) => (node: GraphQLESTreeNode<NameNode>) => {
       if (ignoredNodes.has(node)) {
-        return
+        return;
       }
       if (node.parent.kind === 'Field' && node.parent.alias !== node) {
         return;

--- a/packages/plugin/src/rules/naming-convention/index.ts
+++ b/packages/plugin/src/rules/naming-convention/index.ts
@@ -342,6 +342,7 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
   create(context) {
     const options = context.options[0] || {};
     const { allowLeadingUnderscore, allowTrailingUnderscore, types, ...restOptions } = options;
+    const ignoredNodes = new Set<unknown>()
 
     function normalisePropertyOption(kind: string): PropertySchema {
       const style = (restOptions[kind] || types) as Options;
@@ -403,6 +404,9 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
       } | void {
         const name = nodeName.replace(/(^_+)|(_+$)/g, '');
         if (ignorePattern && new RegExp(ignorePattern, 'u').test(name)) {
+          if ('name' in n) {
+            ignoredNodes.add(n.name)
+          }
           return;
         }
         if (prefix && !name.startsWith(prefix)) {
@@ -485,6 +489,9 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
     };
 
     const checkUnderscore = (isLeading: boolean) => (node: GraphQLESTreeNode<NameNode>) => {
+      if (ignoredNodes.has(node)) {
+        return
+      }
       if (node.parent.kind === 'Field' && node.parent.alias !== node) {
         return;
       }


### PR DESCRIPTION
fixes https://github.com/dimaMachina/graphql-eslint/issues/1719